### PR TITLE
workaround to ensure mem-store is available early enough

### DIFF
--- a/entity.js
+++ b/entity.js
@@ -15,12 +15,6 @@ module.exports = function entity (options) {
 
   opts = extend(opts, options)
 
-  // Ensures legacy versions of seneca that load mem-store do not
-  // crash the system. Seneca 2.x and lower loads mem-store by default.
-  if (!seneca.options().default_plugins['mem-store'] & opts.mem_store) {
-    seneca.use(MemStore)
-  }
-
   return {
     name: 'entity'
   }
@@ -56,6 +50,12 @@ module.exports.preload = function () {
   // store init was already included by default.
   if (!seneca.store || !seneca.store.init) {
     seneca.decorate('store', Store())
+  }
+
+  // Ensures legacy versions of seneca that load mem-store do not
+  // crash the system. Seneca 2.x and lower loads mem-store by default.
+  if (!seneca.options().default_plugins['mem-store'] & opts.mem_store) {
+    seneca.root.use(MemStore)
   }
 
   return {


### PR DESCRIPTION
Using seneca.root avoids delay in loading mem-store.

New plugin system will need to handle loading dependent plugins.