### PR TITLE
Move opts extend to preload

### DIFF
--- a/entity.js
+++ b/entity.js
@@ -10,19 +10,17 @@ var opts = {
 }
 
 module.exports = function entity (options) {
-  var seneca = this
-  var extend = seneca.util.deepextend
-
-  opts = extend(opts, options)
-
   return {
     name: 'entity'
   }
 }
 
 // All functionality should be loaded when defining plugin
-module.exports.preload = function () {
+module.exports.preload = function (context) {
   var seneca = this
+
+  var extend = seneca.util.deepextend
+  opts = extend(opts, context.options)
 
   seneca.util.parsecanon = seneca.util.parsecanon || MakeEntity.parsecanon
 


### PR DESCRIPTION
As mentioned in #24, this fixes options overriding and allows users to disable `mem_store`.

`preload` function gets invoked **before** the default export, thus ignoring `options` received in `function entity`. 

Also, could I vote in favor of **disabling** `mem_store` by default? I don't know how many people actively use the plugin, but I can't tell you _how many times_ this has been a cause of bug-searching and head-scratching for hours. Your whole microservice doesn't work as expected, but _looks like it does_. Until you remember. Your transport layer isn't picking your AMQP config up: it's using the unfathomable `MemStore`! All due to a somewhat hidden property you didn't even remember existed (`mem_store: false`). So you say to yourself: "Crap. This again. Next time, I'll remember about it". And maybe you do, but then the next dev comes along and it's crying wolf all over again.

If this sound a bit like a rant, it's because it probably is. I had to write [a very silly wrapper around Seneca](https://github.com/nfantone/seneca-amqp) whose _main purpose_ is to configure an AMQP transport and **disable `mem_store`**, just to get around this behaviour. And I thought I was covered with that... until I upgraded `seneca-entity` to latest, which re-enabled `mem_store`.

I get the idea behind including the store by default. It's nice when things work out of the box. But it's _nicer_ when you set things up to use a transport and your whole plugin ecosystem uses **that transport**. This is one of those things that "reads nice" when you are taking a look at an online doc, but it practice, it doesn't really work. You should't rely on some magical store (bar demoware) - but if you _do_ want to rely on it, you could always turn it on.